### PR TITLE
Add P2P exchange LocalCoinSwap to no-KYC list

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,27 @@
 
 								<tr>
 									<td class="column1">
+										<a target="_blank" aria-label="No-KYC, 100% P2P, non-custodial exchange" data-balloon-length="medium" data-balloon-pos="up" href="https://localcoinswap.com/">LocalCoinSwap</a> 
+										<span aria-label="P2P" data-balloon-length="small" data-balloon-pos="up"><i class="las la-handshake"  aria-label="P2P" aria-hidden="true"></i></span>
+										<span data-balloon-length="small" data-balloon-pos="down" aria-label="No personal information needed"><i class="las la-user-secret"></i></span>
+										<span data-balloon-length="small" data-balloon-pos="up" aria-label="Refunds without KYC"><i class="las la-hand-holding-usd"></i></span>
+									</td>
+									<td class="column2"><i class="las la-check" aria-hidden="true"></i></span></td>
+									<td class="column3"><i class="las la-times" aria-hidden="true"></i></span></td>
+									<td class="column4"><i class="las la-times green" aria-hidden="true"></i></span></td>
+									<td class="column5"><span><i class="las la-check" aria-hidden="true"></i></span></td>
+									<td class="column6">
+										<span>
+											<i class="las la-check" aria-hidden="true"></i>										
+										</span>
+										<span aria-label="Some sellers accept cash" data-balloon-length="medium" data-balloon-pos="down">
+											<i class="las la-money-bill-wave" aria-hidden="true"></i>
+										</span>
+									</td>
+								</tr>
+
+								<tr>
+									<td class="column1">
 										<a target="_blank" data-balloon-length="medium" data-balloon-pos="up" aria-label="Some sellers may ask for ID verification." href="https://hodlhodl.com/">HodlHodl</a>  
 										<span aria-label="Verified" data-balloon-length="small" data-balloon-pos="up"><i class="las la-shield-alt"  aria-hidden="true"></i></span> 
 										<span aria-label="P2P" data-balloon-length="small" data-balloon-pos="up"><i class="las la-handshake"  aria-label="P2P" aria-hidden="true"></i></span> 


### PR DESCRIPTION
I have created a PR to add LocalCoinSwap to the list. I left out the verified icon but we would welcome independent verification to attain this icon.

We are a proudly KYC-free exchange, with non-custodial trading in a multitude of cryptocurrencies, and healthy daily volume.

We love the concept of KYCNOT, and are humbled to submit this PR for inclusion. If possible, we would also like to write a blog post to promote KYCNOT to our sites users and mailing list, please let us know if that is/isn't allowed.

Thank you and have a great day!